### PR TITLE
Add back link to Valman Print Studio offer page

### DIFF
--- a/com-offer/valman-print-studio/index.html
+++ b/com-offer/valman-print-studio/index.html
@@ -74,6 +74,32 @@
         padding: var(--spacing-lg);
     }
 
+    .back-link {
+        position: fixed;
+        top: var(--spacing-lg);
+        left: var(--spacing-lg);
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        background-color: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(10px);
+        color: var(--color-text-muted);
+        text-decoration: none;
+        border-radius: var(--radius-lg);
+        font-size: 0.9rem;
+        box-shadow: var(--shadow-sm);
+        transition: all 0.2s ease;
+        z-index: 10;
+    }
+
+    .back-link:hover {
+        background-color: rgba(255, 255, 255, 1);
+        color: var(--color-text);
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-md);
+    }
+
     header {
         text-align: center;
         margin-bottom: var(--spacing-lg);
@@ -251,6 +277,9 @@
 </head>
 
 <body>
+    <a href="/" class="back-link">
+        ← Мои контакты
+    </a>
     <div class="page">
         <div class="container">
             <header>


### PR DESCRIPTION
## Summary
- add a persistent "← Мои контакты" link to the Valman Print Studio commercial offer page
- reuse styling consistent with the existing back-link component on other landing pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa54f94d68832eaa846ae1cb56145c