### PR TITLE
Adjust back link layout on mobile

### DIFF
--- a/com-offer/valman-print-studio/index.html
+++ b/com-offer/valman-print-studio/index.html
@@ -74,6 +74,32 @@
         padding: var(--spacing-lg);
     }
 
+    .back-link {
+        position: fixed;
+        top: var(--spacing-lg);
+        left: var(--spacing-lg);
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        background-color: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(10px);
+        color: var(--color-text-muted);
+        text-decoration: none;
+        border-radius: var(--radius-lg);
+        font-size: 0.9rem;
+        box-shadow: var(--shadow-sm);
+        transition: all 0.2s ease;
+        z-index: 10;
+    }
+
+    .back-link:hover {
+        background-color: rgba(255, 255, 255, 1);
+        color: var(--color-text);
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-md);
+    }
+
     header {
         text-align: center;
         margin-bottom: var(--spacing-lg);
@@ -209,6 +235,11 @@
             padding: var(--spacing-md) var(--spacing-sm);
         }
 
+        .back-link {
+            position: static;
+            margin: var(--spacing-xs) 0 var(--spacing-md) var(--spacing-xs);
+        }
+
         .container {
             padding: var(--spacing-md);
             border-radius: var(--radius-md);
@@ -238,6 +269,12 @@
             font-size: 1.35rem;
         }
 
+        .back-link {
+            font-size: 0.85rem;
+            padding: 0.35rem 0.75rem;
+            margin: var(--spacing-xs) 0 var(--spacing-sm) var(--spacing-xs);
+        }
+
         .card {
             padding: var(--spacing-sm);
         }
@@ -251,6 +288,9 @@
 </head>
 
 <body>
+    <a href="/" class="back-link">
+        ← Мои контакты
+    </a>
     <div class="page">
         <div class="container">
             <header>


### PR DESCRIPTION
## Summary
- reposition the Valman Print Studio back-link into normal flow on small screens
- reduce the button's padding and font size on narrow viewports to avoid overlapping content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa54f94d68832eaa846ae1cb56145c