### PR TITLE
Add offer page with base layout and SEO metadata

### DIFF
--- a/src/pages/offer/index.astro
+++ b/src/pages/offer/index.astro
@@ -1,0 +1,14 @@
+---
+import Base from '../../layouts/Base.astro';
+---
+
+<Base
+  title="Оффер — Роман Пуртов"
+  description="Коммерческое предложение"
+  ogUrl="https://roman-purtow.ru/offer"
+  canonical="https://roman-purtow.ru/offer"
+>
+  <main class="min-h-screen flex items-center justify-center">
+    <h1 class="text-4xl font-bold">Offer</h1>
+  </main>
+</Base>


### PR DESCRIPTION
## Summary
Added a new offer page to the website that serves as a commercial proposal landing page with proper SEO configuration.

## Key Changes
- Created new `/offer` route at `src/pages/offer/index.astro`
- Implemented page using the Base layout component with full SEO metadata
- Set up Open Graph and canonical URL tags for proper search engine indexing
- Added placeholder hero section with centered heading

## Implementation Details
- Page title: "Оффер — Роман Пуртов" (Russian language support)
- Meta description: "Коммерческое предложение" (Commercial proposal)
- Configured canonical URL and OG URL to `https://roman-purtow.ru/offer`
- Used Tailwind CSS utilities for responsive full-height layout with centered content

https://claude.ai/code/session_013wUj2bGmWCem4q34Z17vQ7