### PR TITLE
Add dark mode CSS variables for card styling

### DIFF
--- a/src/pages/offer/01.astro
+++ b/src/pages/offer/01.astro
@@ -454,6 +454,8 @@ import CornerNav from '../../components/CornerNav.astro';
   }
 
   :global(.dark) {
+    --card-bg: #1e1e1e;
+    --shadow: 0 4px 30px rgba(0, 0, 0, 0.3);
     --offer-bg: #1a1a1a;
     --offer-bg-subtle: #222222;
     --offer-text-primary: #F9FAFB;


### PR DESCRIPTION
## Summary
Added CSS custom properties to the dark mode theme to support consistent card styling and shadow effects across the offer page.

## Key Changes
- Added `--card-bg` variable set to `#1e1e1e` for dark mode card backgrounds
- Added `--shadow` variable set to `0 4px 30px rgba(0, 0, 0, 0.3)` for dark mode shadow effects

## Implementation Details
These variables are defined within the `:global(.dark)` selector in the offer page styles, making them available throughout the dark theme. The card background color provides a slightly lighter tone than the main offer background (`#1a1a1a`), creating visual hierarchy, while the shadow variable enables consistent depth effects in dark mode.

https://claude.ai/code/session_016Ua2mgjVan2CKrhyQXQUWT