### PR TITLE
Fix offer page wrapper flex direction to align footer

### DIFF
--- a/src/styles/offer-card.css
+++ b/src/styles/offer-card.css
@@ -16,6 +16,7 @@ body {
 .o3-page {
   min-height: 100dvh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 1rem 1rem 2rem;
@@ -619,4 +620,3 @@ body {
   border-color: var(--color-offer-accent);
   box-shadow: 0 0 0 3px rgba(246, 82, 46, 0.25);
 }
-


### PR DESCRIPTION
### Motivation
- Prevent the footer from floating to the right by making the offer page wrapper a column flex container so the card and footer stack vertically while keeping the card centered.

### Description
- Add `flex-direction: column;` to `.o3-page` in `src/styles/offer-card.css` while keeping `align-items: center` and `justify-content: center`, and rely on existing `.o3-footer` rules (`width: 100%; max-width: 720px;`) so footer width matches the card.

### Testing
- Ran `npm run build` which completed successfully, and verified that `src/pages/offer/1.astro`…`4.astro` import `Offer03Card` and that `.o3-page`/`.o3-footer` CSS blocks contain the expected values using `rg`/file inspection (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5175f50c832ea2d9055c5570b2eb)