### PR TITLE
Center offer CTA and simplify /offer/2 process infographic

### DIFF
--- a/src/pages/offer/2.astro
+++ b/src/pages/offer/2.astro
@@ -17,22 +17,38 @@ import OfferFooter from '../../components/offer/OfferFooter.astro';
     <p>Классический процесс создания сайта устроен избыточно. Сначала рисуется макет в Figma — это дни или недели. Потом этот макет «переводится» в код — ещё столько же. Два этапа, которые по сути делают одно и то же.</p>
     <p>Я объединил их в один. Проектирую сайт сразу как готовый продукт — то, что вы видите на экране, уже является рабочим сайтом, а не картинкой в дизайн-программе.</p>
 
-    <div class="o3-process">
+    <div class="o3-process" aria-label="Сравнение подходов по времени">
+      <p class="o3-process-title">Где теряются сроки</p>
+
       <div class="o3-process-row">
-        <span class="o3-process-label">Обычный подход</span>
-        <div class="o3-process-steps">
-          <div class="o3-process-step">Дизайн в Figma</div>
-          <span class="o3-process-arrow">&rarr;</span>
-          <div class="o3-process-step">Вёрстка в код</div>
+        <div class="o3-process-head">
+          <span class="o3-process-label">Обычный подход</span>
+          <span class="o3-process-time">Обычно: недели</span>
         </div>
-        <span class="o3-process-time">Недели</span>
+        <div class="o3-process-steps">
+          <div class="o3-process-step">
+            <span class="o3-process-step-dot">1</span>
+            <span>Дизайн в Figma</span>
+          </div>
+          <span class="o3-process-arrow">+</span>
+          <div class="o3-process-step">
+            <span class="o3-process-step-dot">2</span>
+            <span>Вёрстка в код</span>
+          </div>
+        </div>
       </div>
+
       <div class="o3-process-row o3-process-row--highlight">
-        <span class="o3-process-label">Мой подход</span>
-        <div class="o3-process-steps">
-          <div class="o3-process-step o3-process-step--accent">Дизайн = готовый сайт</div>
+        <div class="o3-process-head">
+          <span class="o3-process-label">Мой подход</span>
+          <span class="o3-process-time">Обычно: дни</span>
         </div>
-        <span class="o3-process-time">Дни</span>
+        <div class="o3-process-steps">
+          <div class="o3-process-step o3-process-step--accent">
+            <span class="o3-process-step-dot o3-process-step-dot--accent">1</span>
+            <span>Сразу делаю дизайн как рабочий сайт</span>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/src/styles/offer-card.css
+++ b/src/styles/offer-card.css
@@ -123,7 +123,8 @@ body {
    CTA Button
    ======================================== */
 .o3-cta {
-  display: inline-block;
+  display: block;
+  width: fit-content;
   padding: 0.8rem 2rem;
   background: var(--color-offer-accent);
   color: #ffffff;
@@ -134,7 +135,7 @@ body {
   cursor: pointer;
   transition: background 0.2s ease, transform 0.15s ease;
   text-decoration: none;
-  margin-top: 0.5rem;
+  margin: 0.5rem auto 0;
 }
 
 .o3-cta:hover {
@@ -321,112 +322,139 @@ body {
 .o3-process {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.875rem;
   margin: 1.25rem 0;
-  font-size: clamp(13px, 1.2vw, 15px);
+  padding: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.875rem;
+  background: #fbfbfb;
+}
+
+.o3-process-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-text);
 }
 
 .o3-process-row {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.875rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 0.75rem;
+  background: #fff;
 }
 
 .o3-process-row--highlight {
-  border-color: var(--color-offer-accent);
-  border-width: 2px;
-  background: rgba(246, 82, 46, 0.04);
+  border-color: rgba(246, 82, 46, 0.4);
+  background: rgba(246, 82, 46, 0.05);
+}
+
+.o3-process-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .o3-process-label {
-  font-weight: 600;
-  font-size: 0.8em;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-muted);
-  min-width: 5.5rem;
-  flex-shrink: 0;
+  color: var(--color-text);
 }
 
 .o3-process-row--highlight .o3-process-label {
   color: var(--color-offer-accent);
 }
 
+.o3-process-time {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
 .o3-process-steps {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  flex: 1;
 }
 
 .o3-process-step {
-  padding: 0.4rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.625rem;
   background: #f5f5f4;
-  border-radius: 0.5rem;
-  font-weight: 500;
   color: var(--color-text);
-  white-space: nowrap;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.o3-process-step-dot {
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #fff;
+  background: #6b7280;
 }
 
 .o3-process-step--accent {
   background: var(--color-offer-accent);
   color: #fff;
-  font-weight: 600;
+}
+
+.o3-process-step-dot--accent {
+  background: rgba(255, 255, 255, 0.25);
 }
 
 .o3-process-arrow {
   color: var(--color-text-muted);
-  font-size: 1.2em;
-  flex-shrink: 0;
+  font-weight: 700;
 }
 
-.o3-process-time {
-  font-size: 0.85em;
-  color: var(--color-text-muted);
-  font-weight: 500;
-  margin-left: auto;
-  flex-shrink: 0;
-}
-
-@media (max-width: 480px) {
-  .o3-process-row {
-    flex-wrap: wrap;
-    gap: 0.5rem;
+@media (max-width: 560px) {
+  .o3-process {
+    padding: 0.75rem;
   }
 
-  .o3-process-label {
-    width: 100%;
+  .o3-process-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
   }
 
   .o3-process-steps {
-    width: 100%;
+    flex-wrap: wrap;
   }
+}
 
-  .o3-process-step {
-    white-space: normal;
-    font-size: 0.9em;
-  }
-
-  .o3-process-time {
-    width: 100%;
-    text-align: right;
-  }
+.dark .o3-process {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .dark .o3-process-row {
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.2);
 }
 
 .dark .o3-process-row--highlight {
-  background: rgba(246, 82, 46, 0.08);
-  border-color: var(--color-offer-accent);
+  border-color: rgba(246, 82, 46, 0.65);
+  background: rgba(246, 82, 46, 0.1);
 }
 
 .dark .o3-process-step {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.09);
   color: var(--color-text-light);
 }
 


### PR DESCRIPTION
### Motivation
- The primary CTA on `/offer/*` was visually left-aligned and needed to be centered for consistent presentation. 
- The process infographic on `/offer/2` was overly abstract and hard to scan, so it needed a simpler, more readable layout that works well on mobile and in dark mode.

### Description
- Centered the shared offer CTA by updating `src/styles/offer-card.css` to set `.o3-cta` to `display: block`, `width: fit-content`, and `margin: 0.5rem auto 0` so buttons are horizontally centered.
- Rewrote the `/offer/2` infographic markup in `src/pages/offer/2.astro` to add an explicit section title, an accessible `aria-label`, a header/time row, and numbered step badges for clearer, human-readable steps.
- Reworked process styles in `src/styles/offer-card.css` to improve contrast, spacing, and structure by adding `.o3-process-title`, `.o3-process-head`, `.o3-process-step-dot`, updated highlight/dark-mode rules, and mobile tweaks for better responsiveness.

### Testing
- Ran the static site build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd54372de4832ea812c3ff981d9597)